### PR TITLE
Jenkins signing fix for 1.0 branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,12 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
Jenkins build https://ci.eclipse.org/microprofile/view/Release/job/MicroProfile%20Releases/302/console encountered the same signing error,

```
[INFO] [INFO] --- maven-gpg-plugin:1.6:sign (sign-artifacts) @ microprofile-context-propagation-parent ---
[INFO] gpg: signing failed: Not a tty
[INFO] gpg: signing failed: Not a tty
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] Reactor Summary for MicroProfile Context Propagation 1.0.2:
[INFO] [INFO] 
[INFO] [INFO] MicroProfile Context Propagation ................... FAILURE [01:07 min]
[INFO] [INFO] MicroProfile Context Propagation ................... SKIPPED
[INFO] [INFO] microprofile-context-propagation-tck ............... SKIPPED
[INFO] [INFO] MicroProfile Context Propagation Specification ..... SKIPPED
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] BUILD FAILURE
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] Total time:  01:33 min
[INFO] [INFO] Finished at: 2019-12-19T21:06:32Z
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-gpg-plugin:1.6:sign (sign-artifacts) on project microprofile-context-propagation-parent: Exit code: 2 -> [Help 1]
```

which has been fixed in other microprofile projects by:
https://github.com/eclipse/microprofile-metrics/pull/485/files
https://github.com/eclipse/microprofile-fault-tolerance/pull/489/files

Applying the same change to MicroProfile Context Propagation 1.0 branch here.