### PR TITLE
Discontinue per microprofile-wg 234

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
+// Copyright (c) 2018,2024 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -25,7 +25,7 @@ image:https://badges.gitter.im/eclipse/microprofile-concurrency.svg[link="https:
 
 :toc:
 
-* Status: *new*
+* Status: *discontinued* (this specification is replaced by Jakarta Concurrency)
 * Decision Notes:
 https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/microprofile/jKFu-IS_U90[Discussion
 thread topic with background and covering the design]

--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@ image:https://badges.gitter.im/eclipse/microprofile-concurrency.svg[link="https:
 
 :toc:
 
-* Status: *discontinued* (this specification is replaced by Jakarta Concurrency)
+* Status: *discontinued* (this specification is replaced by https://github.com/jakartaee/concurrency[Jakarta Concurrency])
 * Decision Notes:
 https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/microprofile/jKFu-IS_U90[Discussion
 thread topic with background and covering the design]


### PR DESCRIPTION
As decided on the MicroProfile Community calls and documented in https://github.com/microprofile/microprofile-wg/issues/234 , the MicroProfile Context Propagation specification is being discontinued in favor of Jakarta EE Concurrency, which the innovations from MicroProfile Context Propagation have been going into.